### PR TITLE
Increase initial guess for Ragnaros combat start timer

### DIFF
--- a/DBM-Raids-Vanilla/MC/Ragnaros.lua
+++ b/DBM-Raids-Vanilla/MC/Ragnaros.lua
@@ -43,7 +43,7 @@ local warnEmerge		= mod:NewAnnounce("WarnEmerge", 2, "Interface\\AddOns\\DBM-Cor
 local timerWrathRag		= mod:NewCDTimer(25, 20566, nil, nil, nil, 2)--25-30
 local timerSubmerge		= mod:NewTimer(180, "TimerSubmerge", "Interface\\AddOns\\DBM-Core\\textures\\CryptFiendBurrow.blp", nil, nil, 6)
 local timerEmerge		= mod:NewTimer(90, "TimerEmerge", "Interface\\AddOns\\DBM-Core\\textures\\CryptFiendUnBurrow.blp", nil, nil, 6)
-local timerCombatStart	= mod:NewTimer(73, "timerCombatStart", "132349", nil, nil, nil, nil, nil, 1, 3)
+local timerCombatStart	= mod:NewTimer(83, "timerCombatStart", "132349", nil, nil, nil, nil, nil, 1, 3)
 
 mod.vb.addLeft = 8
 mod.vb.ragnarosEmerged = true
@@ -157,14 +157,7 @@ function mod:OnSync(msg)
 		self.vb.addLeft = self.vb.addLeft + 8
 	elseif msg == "DomoDeath" and self:AntiSpam(5, 3) then
 		--The timer between yell/summon start and ragnaros being attackable is variable, but time between domo death and him being attackable is not.
-		--As such, we start lowest timer of that variation on the RP start, but adjust timer if it's less than 10 seconds at time domo dies
-		local remaining = timerCombatStart:GetRemaining()
-		if remaining then
-			if remaining < 10 then
-				timerCombatStart:AddTime(10 - remaining)
-			elseif remaining > 10 then
-				timerCombatStart:RemoveTime(remaining - 10)
-			end
-		end
+		--As such, we start with a reasonable guess on the RP start, but adjust timer to 10 seconds once domo dies.
+		timerCombatStart:Update(73, 83)
 	end
 end


### PR DESCRIPTION
I randomly watched some HC WoW streams on Twitch the other day and noticed people being confused by the Ragnaros combat start timer. Looks like the current logic makes a low estimate for the actual time and then adjusts the timer later. The problem is that the low estimate realistically seems to pretty much match part 1 of the time (RP start to Majordomo death) which also triggers the voice announces etc prior to the timer being updated last second, so people think the timer is wrong.
So let's use a higher initial estimate instead, worst case it suddenly jumps by 10 seconds but based on 2 random streams I watched the new estimate seems about right.

Here's a clip where the current confusing behavior can be observed: https://clips.twitch.tv/GenerousOpenMoonYouWHY-wm0zm5J4MXjj6-t3

Also use Update() instead of Add/RemoveTime() because it's easier and has the nice side effect of actually starting the timer in case it expired or something

Tested: no, I don't even have WoW installed and I have no clue what I'm doing after > 10 years of not contributing anything, so, uhm, maybe someone should actually test this?