### PR TITLE
Register event SWING_MISSED

### DIFF
--- a/DBM-Raids-Vanilla/AQ40/AQ40Trash.lua
+++ b/DBM-Raids-Vanilla/AQ40/AQ40Trash.lua
@@ -38,6 +38,7 @@ local eventsRegistered = true
 mod:RegisterShortTermEvents(
 	"SPELL_MISSED",
 	"SWING_DAMAGE",
+	"SWING_MISSED",
 	"SPELL_PERIODIC_DAMAGE",
 	"SPELL_PERIODIC_MISSED"
 )


### PR DESCRIPTION
That might have been an ancient bug.

Not a bug that anyone would realistically notice, but still interesting to find something like this :)