### PR TITLE
Fix for Classic Era Loatheb Corrupted Mind.

### DIFF
--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
@@ -8,8 +8,8 @@ mod:SetModelID(16110)
 mod:RegisterCombat("combat")--Maybe change to a yell later so pull detection works if you chain pull him from tash gauntlet
 
 mod:RegisterEventsInCombat(
-	"SPELL_AURA_APPLIED 29185 29194 29196 29198",-- 29184 29195 29197 29199
-	"SPELL_AURA_REMOVED 29185 29194 29196 29198",-- 29184 29195 29197 29199
+	"SPELL_AURA_APPLIED 29185 29194 29196 29198 29201",-- 29184 29195 29197 29199
+	"SPELL_AURA_REMOVED 29185 29194 29196 29198 29201",-- 29184 29195 29197 29199
 	"SPELL_CAST_SUCCESS 29234 29204 30281",
 	"UNIT_DIED"
 )
@@ -128,7 +128,7 @@ end
 --29185--Priest
 --29198--Shaman
 function mod:SPELL_AURA_APPLIED(args)
-	if args:IsSpell(29185, 29194, 29196, 29198) and DBM:UnitDebuff(args.destName, 29184, 29195, 29197, 29199) then
+	if args:IsSpell(29185, 29194, 29196, 29198, 29201) and DBM:UnitDebuff(args.destName, 29184, 29195, 29197, 29199) then
 		hadCorrupted[args.destName] = GetTime() + 60
 		if args:IsPlayer() then
 			warnHealSoon:Schedule(55)
@@ -137,7 +137,7 @@ function mod:SPELL_AURA_APPLIED(args)
 end
 
 function mod:SPELL_AURA_REMOVED(args)
-	if args:IsSpell(29185, 29194, 29196, 29198) and not DBM:UnitDebuff(args.destName, 29184, 29195, 29197, 29199) then
+	if args:IsSpell(29185, 29194, 29196, 29198, 29201) and not DBM:UnitDebuff(args.destName, 29184, 29195, 29197, 29199) then
 		if args:IsPlayer() then
 			warnHealNow:Show()
 		end


### PR DESCRIPTION
Classic Era is using the TBC Spell ID for Corrupted Mind after SoD release.