### PR TITLE
Update Sunken Temple based on my first raid

### DIFF
--- a/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Vanilla.toc
+++ b/DBM-Raids-Vanilla/DBM-Raids-Vanilla_Vanilla.toc
@@ -127,7 +127,7 @@ VanillaSoD_SunkenTemple\Atalalarion.lua
 VanillaSoD_SunkenTemple\FesteringRotslime.lua
 VanillaSoD_SunkenTemple\AtalaiDefenders.lua
 VanillaSoD_SunkenTemple\DreamscytheAndWeaver.lua
-VanillaSoD_SunkenTemple\AvatarofHakkar.lua
 VanillaSoD_SunkenTemple\JammalanAndOgom.lua
 VanillaSoD_SunkenTemple\MorphazAndHazzas.lua
 VanillaSoD_SunkenTemple\ShadeOfEranikus.lua
+VanillaSoD_SunkenTemple\AvatarofHakkar.lua

--- a/DBM-Raids-Vanilla/VanillaSoD_SunkenTemple/Atalalarion.lua
+++ b/DBM-Raids-Vanilla/VanillaSoD_SunkenTemple/Atalalarion.lua
@@ -14,16 +14,19 @@ mod:RegisterEventsInCombat(
 	"SPELL_CAST_START 437503 437597"
 )
 
+--https://www.wowhead.com/classic/spell=448995/rune-scrying are doorway blocker NPCs, on every boss, ignore these
+
 --[[
 (ability.id = 437503 or ability.id = 437597) and type = "begincast"
 --]]
---https://www.wowhead.com/classic/spell=448995/rune-scrying cast by trash mob if you don't pull balcony?
 local warnPillarsOfMight			= mod:NewCountAnnounce(437503, 3)
 
 local specWarnDemolishingSmash		= mod:NewSpecialWarningCount(437597, nil, nil, nil, 2, 2)
 
-local timerPillarsofMightCD			= mod:NewCDCountTimer(12.9, 437503, nil, nil, nil, 1, nil, DBM_COMMON_L.DAMAGE_ICON)--12.9-14.5
-local timerDemolishingSmashCD		= mod:NewCDCountTimer(27.5, 437597, nil, nil, nil, 3)--27.5-29.1
+--12.2-14.6 "Pillars of Might-437503-npc:218624-0000143F40 = pull:6.4, 21.0, 13.4, 13.7, 12.2, 18.3, 13.6, 14.6, 13.6, 15.6",
+local timerPillarsofMightCD			= mod:NewCDCountTimer(12.2, 437503, nil, nil, nil, 1, nil, DBM_COMMON_L.DAMAGE_ICON)
+--27.1-29.2 "Demolishing Smash-437597-npc:218624-0000143F40 = pull:21.3, 27.1, 29.1, 29.1, 29.2"
+local timerDemolishingSmashCD		= mod:NewCDCountTimer(27.1, 437597, nil, nil, nil, 3)
 
 mod.vb.pillarsCount = 0
 mod.vb.smashCount = 0
@@ -31,8 +34,8 @@ mod.vb.smashCount = 0
 function mod:OnCombatStart(delay)
 	self.vb.pillarsCount = 0
 	self.vb.smashCount = 0
-	timerPillarsofMightCD:Start(4.8-delay, 1)
-	timerDemolishingSmashCD:Start(22.6-delay, 1)--22.6-44.5
+	timerPillarsofMightCD:Start(4.8 - delay, 1)
+	timerDemolishingSmashCD:Start(21.3 - delay, 1)--21.3-44.5
 end
 
 

--- a/DBM-Raids-Vanilla/VanillaSoD_SunkenTemple/MorphazAndHazzas.lua
+++ b/DBM-Raids-Vanilla/VanillaSoD_SunkenTemple/MorphazAndHazzas.lua
@@ -69,6 +69,7 @@ function mod:OnCombatStart(delay)
 --	timerBackfireCD:Start(6.2-delay, 1)
 --	timerDreamersLamentCD:Start(6.2-delay, 1)
 	timerCorruptedBreathCD:Start(10.6-delay)
+	self:SetStage(1)
 end
 
 function mod:SPELL_CAST_START(args)

--- a/DBM-Raids-Vanilla/localization.de.lua
+++ b/DBM-Raids-Vanilla/localization.de.lua
@@ -1257,6 +1257,11 @@ L = DBM:GetModLocalization("AtalaiDefendersSoD")
 L:SetGeneralLocalization({
 	name = "Verteidiger der Atal'ai"
 })
+
+L:SetOptionLocalization({
+	SetIconsOnGhosts = "Setze Icons auf Geisterbosse"
+})
+
 ---------------------------
 --  Dreamscythe and Weaver  --
 ---------------------------

--- a/DBM-Raids-Vanilla/localization.en.lua
+++ b/DBM-Raids-Vanilla/localization.en.lua
@@ -1293,6 +1293,11 @@ L = DBM:GetModLocalization("AtalaiDefendersSoD")
 L:SetGeneralLocalization({
 	name = "Atal'ai Defenders"
 })
+
+L:SetOptionLocalization({
+	SetIconsOnGhosts = "Set icons on ghost bosses"
+})
+
 ---------------------------
 --  Dreamscythe and Weaver  --
 ---------------------------


### PR DESCRIPTION
* Atal'arion: adjust pillar timers
* Rotslime: add yell for players being eaten
* Rotslime: fix special warning for standing in gunk
* Rotslime: add warnings for boss speed up/slow down
* Atalai Defenders: add option to set icons on ghosts
* Atalai Defenders: totems are now a special warning
* Fix order of bosses