### PR TITLE
Update localization.kr.lua

### DIFF
--- a/DBM-Raids-Vanilla/localization.kr.lua
+++ b/DBM-Raids-Vanilla/localization.kr.lua
@@ -1277,7 +1277,7 @@ L:SetGeneralLocalization({
 L = DBM:GetModLocalization("AtalaiDefendersSoD")
 
 L:SetGeneralLocalization({
-	name = "아탈라이 수호자들"
+	name = "아탈라이 파수병"
 })
 
 L:SetOptionLocalization({


### PR DESCRIPTION
Official Blizzard name for Atal'ai Defenders is 아탈라이 파수병 

Source:
https://wago.tools/db2/DungeonEncounter?build=1.15.2.54092&page=1&filter[MapID]=exact%3A109&locale=koKR

ID 2954

@Elnarfim 