### PR TITLE
fix: Loatheb Corrupted Mind doesn't refresh timer

### DIFF
--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
@@ -83,7 +83,8 @@ function mod:OnCombatStart(delay)
 		local _, cls = UnitClass(uId)
 		local _, _, _, mapId = UnitPosition(uId)
 		if not UnitIsDeadOrGhost(uId) and mapId == 533 and (cls == "DRUID" or cls == "PALADIN" or cls == "PRIEST" or cls == "SHAMAN") then
-			hadCorrupted[UnitName(uId)] = startTime
+			local unitName = DBM:GetShortServerName(DBM:GetUnitFullName(uId))
+			hadCorrupted[unitName] = startTime
 		end
 	end
 	if self.Options.InfoFrame and not DBM.InfoFrame:IsShown() then

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
@@ -79,11 +79,11 @@ function mod:OnCombatStart(delay)
 
 	local startTime = GetTime()
 	table.wipe(hadCorrupted)
-	for unit in DBM:GetGroupMembers() do
-		local _, cls = UnitClass(unit)
-		local _, _, _, mapId = UnitPosition(unit)
-		if not UnitIsDeadOrGhost(unit) and mapId == 533 and (cls == "DRUID" or cls == "PALADIN" or cls == "PRIEST" or cls == "SHAMAN") then
-			hadCorrupted[UnitName(unit)] = startTime
+	for uId in DBM:GetGroupMembers() do
+		local _, cls = UnitClass(uId)
+		local _, _, _, mapId = UnitPosition(uId)
+		if not UnitIsDeadOrGhost(uId) and mapId == 533 and (cls == "DRUID" or cls == "PALADIN" or cls == "PRIEST" or cls == "SHAMAN") then
+			hadCorrupted[UnitName(uId)] = startTime
 		end
 	end
 	if self.Options.InfoFrame and not DBM.InfoFrame:IsShown() then

--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
@@ -7,9 +7,24 @@ mod:SetEncounterID(1115)
 mod:SetModelID(16110)
 mod:RegisterCombat("combat")--Maybe change to a yell later so pull detection works if you chain pull him from tash gauntlet
 
+-- There are two types of Corrupted Mind spells for each class.
+-- Let's refer to them as "Corrupted Mind Aura" and "Corrupted Mind Debuff" for clarify
+-- Corrupted Mind Aura
+--   * This is a 2 min debuff that gives you a Corrupted Mind Debuff if you cast a heal.
+--   * This is refreshed every 11 seconds if you're in combat with Loatheb.
+-- Corrupted Mind Debuff
+--   * This is a 1 min debuff that doesn't let you heal.
+--   * This is applied if you heal when you have the Corrupted Mind Aura.
+
+-- Corrupted Mind Aura spell IDs (in the order of Priest, Druid, Paladin, Shaman)
+-- 29185 29194 29196 29198
+
+-- Corrupted Mind Debuff spell IDs (in the order of Priest, Druid, Paladin, Shaman)
+-- 29184 29195 29197 29199
+
 mod:RegisterEventsInCombat(
-	"SPELL_AURA_APPLIED 29185 29194 29196 29198 29201",-- 29184 29195 29197 29199
-	"SPELL_AURA_REMOVED 29185 29194 29196 29198 29201",-- 29184 29195 29197 29199
+	"SPELL_AURA_APPLIED 29184 29195 29197 29199",
+	"SPELL_AURA_REMOVED 29184 29195 29197 29199",
 	"SPELL_CAST_SUCCESS 29234 29204 30281",
 	"UNIT_DIED"
 )
@@ -124,12 +139,8 @@ function mod:SPELL_CAST_SUCCESS(args)
 	end
 end
 
---29194--Druid
---29196--Paladin
---29185--Priest
---29198--Shaman
 function mod:SPELL_AURA_APPLIED(args)
-	if args:IsSpell(29185, 29194, 29196, 29198, 29201) and DBM:UnitDebuff(args.destName, 29184, 29195, 29197, 29199) then
+	if args:IsSpell(29184, 29195, 29197, 29199) then
 		hadCorrupted[args.destName] = GetTime() + 60
 		if args:IsPlayer() then
 			warnHealSoon:Schedule(55)
@@ -138,7 +149,7 @@ function mod:SPELL_AURA_APPLIED(args)
 end
 
 function mod:SPELL_AURA_REMOVED(args)
-	if args:IsSpell(29185, 29194, 29196, 29198, 29201) and not DBM:UnitDebuff(args.destName, 29184, 29195, 29197, 29199) then
+	if args:IsSpell(29184, 29195, 29197, 29199) then
 		if args:IsPlayer() then
 			warnHealNow:Show()
 		end


### PR DESCRIPTION
**Context**
- Track SPELL_AURA_APPLIED for "Corrupted Mind Debuff" instead of "Corrupted Mind Aura"
- Use shortServerName for unitName to fix adding name different realm when the aura's refreshed.

**Ref**
- Corrupted Mind Aura
  - This is a 2 min debuff that gives you a Corrupted Mind Debuff if you cast a heal.
  - This is refreshed every 11 seconds if you're in combat with Loatheb.
- Corrupted Mind Debuff
  - This is a 1 min debuff that doesn't let you heal.
  - This is applied if you heal when you have the Corrupted Mind Aura.

**Changes**
- initialization
  - RegisterEventsInCombat for "Corrupted Mind Debuff" spell IDs
- mod:OnCombatStart
  - renamed unit to Uid
  - Get full unit name with realm using DBM:GetUnitFullName e.g. Junsa-Mankrik
  - Shorten it using DBM::GetShortServerName e.g. Junsa* (if the realm is different from the player's) or Junsa (if the realm is the same as the player's)
  - use the shortServerName to initialize hadCorrupted
- mod:SPELL_AURA_APPLIED, mod:SPELL_AURA_REMOVED
  - Refresh hadCorrupted time if "Corrupted Mind Debuff" spell is casted
  - Remove debuff check as it is redudant.
