### PR TITLE
Revert "fix: Loatheb hadCorrupted should use shortServerName"

### DIFF
--- a/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
+++ b/DBM-Raids-Vanilla/VanillaNaxx/PlagueQuarter/Loatheb.lua
@@ -98,8 +98,7 @@ function mod:OnCombatStart(delay)
 		local _, cls = UnitClass(uId)
 		local _, _, _, mapId = UnitPosition(uId)
 		if not UnitIsDeadOrGhost(uId) and mapId == 533 and (cls == "DRUID" or cls == "PALADIN" or cls == "PRIEST" or cls == "SHAMAN") then
-			local unitName = DBM:GetShortServerName(DBM:GetUnitFullName(uId))
-			hadCorrupted[unitName] = startTime
+			hadCorrupted[UnitName(uId)] = startTime
 		end
 	end
 	if self.Options.InfoFrame and not DBM.InfoFrame:IsShown() then


### PR DESCRIPTION
**Context**
- It shows no name for group members in different realm
- Reverting the change for now.
- It's going to go back to the version with the bug where two separate names show for the same member if they are from different realm. (one with asterisk and another without)

This reverts commit ce53e387387d52077cb1ac9f97ed7a6876104b4f.