### PR TITLE
Split .pkgmeta by release type

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
         uses: BigWigsMods/packager@master
         if: ${{ github.event_name != 'pull_request' }}
         with:
-          args: -n "DBM-Vanilla_SoD_BC-{project-version}{classic}"
+          # Ugly hack to use a different .pkgmeta for alpha builds to work around https://github.com/BigWigsMods/packager/issues/165
+          args: -n "DBM-Vanilla_SoD_BC-{project-version}{classic}" $(if [[ -z $(git tag --points-at HEAD) ]]; then echo "-m .pkgmeta-alpha" ; else echo "-m .pkgmeta" ; fi)
         env:
           CF_API_KEY: ${{ secrets.CF_API_KEY }}
           GITHUB_OAUTH: ${{ secrets.GITHUB_TOKEN }}

--- a/.pkgmeta-alpha
+++ b/.pkgmeta-alpha
@@ -7,6 +7,4 @@ move-folders:
     DBM-Raids-BC/DBM-Outlands: DBM-Outlands
     DBM-Raids-BC/DBM-Azeroth: DBM-Azeroth
     DBM-Raids-BC/DBM-Raids-BC: DBM-Raids-BC
-
-ignore:
-  - DBM-Raids-BC/DBM-Test-BCVanilla: DBM-Test-BCVanilla
+    DBM-Raids-BC/DBM-Test-BCVanilla: DBM-Test-BCVanilla

--- a/DBM-Test-BCVanilla/DBM-Test-BCVanilla.toc
+++ b/DBM-Test-BCVanilla/DBM-Test-BCVanilla.toc
@@ -1,4 +1,3 @@
-#@alpha@
 ## Interface: 100206
 ## Interface-Classic: 11502
 ## Interface-Wrath: 30403
@@ -11,4 +10,3 @@
 
 Season of Discovery/Sunken Temple/Atal'arion.lua
 Season of Discovery/Sunken Temple/Reports/Atal'arion.lua
-#@end-alpha@


### PR DESCRIPTION
This seems to be the only way to fully exclude a whole addon from release builds.

https://github.com/BigWigsMods/packager/issues/165